### PR TITLE
add f32 binary operation traits for tensor

### DIFF
--- a/tensor/src/lib.rs
+++ b/tensor/src/lib.rs
@@ -157,10 +157,8 @@ impl Tensor {
     }
 
     pub fn mean(&self) -> Tensor {
-        let sum: f32 = self.data().iter().sum();
-        let size: usize = self.shape().iter().product();
-        let mean: f32 = sum / size as f32;
-        Tensor::new(vec![1], vec![mean]).unwrap()
+        let sum: Tensor = self.sum();
+        &sum / self.shape().iter().product::<usize>() as f32
     }
 
     pub fn mean_dim(&self, dim: usize) -> Result<Tensor, &'static str> {
@@ -168,8 +166,7 @@ impl Tensor {
             return Err("Dimension out of range for the tensor");
         }
         let sum: Tensor = self.sum_dim(dim).unwrap();
-        let size_tensor: Tensor = Tensor::new(vec![1], vec![self.shape()[dim] as f32]).unwrap();
-        Ok(sum / size_tensor)
+        Ok(&sum / self.shape()[dim] as f32)
     }
 
     /* UNARY OPS */
@@ -615,10 +612,10 @@ impl Index<Vec<usize>> for Tensor {
     }
 }
 
-impl Add<Tensor> for Tensor {
+impl Add<&Tensor> for &Tensor {
     type Output = Tensor;
 
-    fn add(self, rhs: Tensor) -> Self::Output {
+    fn add(self, rhs: &Tensor) -> Self::Output {
         match Tensor::add(&self, &rhs) {
             Ok(result) => result,
             Err(_) => panic!("Shapes of the tensors do not match for addition."),
@@ -626,10 +623,28 @@ impl Add<Tensor> for Tensor {
     }
 }
 
-impl Sub<Tensor> for Tensor {
+impl Add<f32> for &Tensor {
     type Output = Tensor;
 
-    fn sub(self, rhs: Tensor) -> Self::Output {
+    fn add(self, rhs: f32) -> Self::Output {
+        let result_data: Vec<f32> = self.data().iter().map(|&x| x + rhs).collect();
+        Tensor::new(self.shape().clone(), result_data).unwrap()
+    }
+}
+
+impl Add<&Tensor> for f32 {
+    type Output = Tensor;
+
+    fn add(self, rhs: &Tensor) -> Self::Output {
+        let result_data: Vec<f32> = rhs.data().iter().map(|&x| x + self).collect();
+        Tensor::new(rhs.shape().clone(), result_data).unwrap()
+    }
+}
+
+impl Sub<&Tensor> for &Tensor {
+    type Output = Tensor;
+
+    fn sub(self, rhs: &Tensor) -> Self::Output {
         match Tensor::sub(&self, &rhs) {
             Ok(result) => result,
             Err(_) => panic!("Shapes of the tensors do not match for subtraction."),
@@ -637,10 +652,28 @@ impl Sub<Tensor> for Tensor {
     }
 }
 
-impl Mul<Tensor> for Tensor {
+impl Sub<f32> for &Tensor {
     type Output = Tensor;
 
-    fn mul(self, rhs: Tensor) -> Self::Output {
+    fn sub(self, rhs: f32) -> Self::Output {
+        let result_data: Vec<f32> = self.data().iter().map(|&x| x - rhs).collect();
+        Tensor::new(self.shape().clone(), result_data).unwrap()
+    }
+}
+
+impl Sub<&Tensor> for f32 {
+    type Output = Tensor;
+
+    fn sub(self, rhs: &Tensor) -> Self::Output {
+        let result_data: Vec<f32> = rhs.data().iter().map(|&x| x - self).collect();
+        Tensor::new(rhs.shape().clone(), result_data).unwrap()
+    }
+}
+
+impl Mul<&Tensor> for &Tensor {
+    type Output = Tensor;
+
+    fn mul(self, rhs: &Tensor) -> Self::Output {
         match Tensor::mul(&self, &rhs) {
             Ok(result) => result,
             Err(_) => panic!("Shapes of the tensors do not match for multiplication."),
@@ -648,13 +681,40 @@ impl Mul<Tensor> for Tensor {
     }
 }
 
-impl Div<Tensor> for Tensor {
+impl Mul<f32> for &Tensor {
     type Output = Tensor;
 
-    fn div(self, rhs: Tensor) -> Self::Output {
+    fn mul(self, rhs: f32) -> Self::Output {
+        let result_data: Vec<f32> = self.data().iter().map(|&x| x * rhs).collect();
+        Tensor::new(self.shape().clone(), result_data).unwrap()
+    }
+}
+
+impl Mul<&Tensor> for f32 {
+    type Output = Tensor;
+
+    fn mul(self, rhs: &Tensor) -> Self::Output {
+        let result_data: Vec<f32> = rhs.data().iter().map(|&x| x * self).collect();
+        Tensor::new(rhs.shape().clone(), result_data).unwrap()
+    }
+}
+
+impl Div<&Tensor> for &Tensor {
+    type Output = Tensor;
+
+    fn div(self, rhs: &Tensor) -> Self::Output {
         match Tensor::div(&self, &rhs) {
             Ok(result) => result,
             Err(_) => panic!("Shapes of the tensors do not match for division."),
         }
+    }
+}
+
+impl Div<f32> for &Tensor {
+    type Output = Tensor;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        let result_data: Vec<f32> = self.data().iter().map(|&x| x / rhs).collect();
+        Tensor::new(self.shape().clone(), result_data).unwrap()
     }
 }

--- a/tensor/tests/tensor_core_test.rs
+++ b/tensor/tests/tensor_core_test.rs
@@ -330,9 +330,16 @@ fn tensor_addition_operator() {
     let shape = vec![4, 2];
     let a = Tensor::ones(shape.clone());
     let b = Tensor::ones(shape);
-    let result = a + b;
+    let result = &a + &b;
 
     let expected_data = vec![2.0_f32; 8];
+    assert_eq!(expected_data, *result.data());
+
+    let result = &a + 2.0_f32;
+    let expected_data = vec![3.0_f32; 8];
+    assert_eq!(expected_data, *result.data());
+
+    let result = 2.0 + &a;
     assert_eq!(expected_data, *result.data());
 }
 
@@ -348,7 +355,7 @@ fn tensor_broadcasted_addition_operator() {
     let a_tensor = Tensor::new(a_shape, a_data).unwrap();
     let b_tensor = Tensor::new(b_shape, b_data).unwrap();
 
-    let c = a_tensor + b_tensor;
+    let c = &a_tensor + &b_tensor;
     let expected_data = vec![
         1_f32, 2_f32, 3_f32, 11_f32, 12_f32, 13_f32, 21_f32, 22_f32, 23_f32, 31_f32, 32_f32, 33_f32,
     ];
@@ -394,9 +401,16 @@ fn tensor_subtraction_operator() {
     let shape = vec![4, 2];
     let a = Tensor::ones(shape.clone());
     let b = Tensor::ones(shape);
-    let result = a - b;
 
+    let result = &a - &b;
     let expected_data = vec![0.0_f32; 8];
+    assert_eq!(expected_data, *result.data());
+
+    let result = &a - 2.0_f32;
+    let expected_data = vec![-1.0_f32; 8];
+    assert_eq!(expected_data, *result.data());
+
+    let result = 2.0 - &a;
     assert_eq!(expected_data, *result.data());
 }
 
@@ -412,7 +426,7 @@ fn tensor_broadcasted_subtraction_operator() {
     let a_tensor = Tensor::new(a_shape, a_data).unwrap();
     let b_tensor = Tensor::new(b_shape, b_data).unwrap();
 
-    let c = a_tensor - b_tensor;
+    let c = &a_tensor - &b_tensor;
     let expected_data = vec![
         -1_f32, -2_f32, -3_f32, 9_f32, 8_f32, 7_f32, 19_f32, 18_f32, 17_f32, 29_f32, 28_f32, 27_f32,
     ];
@@ -458,8 +472,15 @@ fn tensor_mul_operator() {
     let a_tensor = Tensor::new(a_shape, a_data).unwrap();
     let b_tensor = Tensor::new(b_shape, b_data).unwrap();
 
-    let c = a_tensor * b_tensor;
+    let c = &a_tensor * &b_tensor;
     let expected = vec![3_f32, 4_f32, 3_f32];
+    assert_eq!(expected, *c.data());
+
+    let c = &a_tensor * 2.0;
+    let expected = vec![2_f32, 4_f32, 6_f32];
+    assert_eq!(expected, *c.data());
+
+    let c = 2.0 * &a_tensor;
     assert_eq!(expected, *c.data());
 }
 
@@ -515,8 +536,12 @@ fn tensor_div_operator() {
     let a_tensor = Tensor::new(a_shape, a_data).unwrap();
     let b_tensor = Tensor::new(b_shape, b_data).unwrap();
 
-    let c = a_tensor / b_tensor;
+    let c = &a_tensor / &b_tensor;
     let expected = vec![(1_f32 / 3_f32), 1_f32, 3_f32];
+    assert_eq!(expected, *c.data());
+
+    let c = &a_tensor / 2.0;
+    let expected = vec![(1_f32 / 2_f32), 1_f32, 3_f32 / 2.0];
     assert_eq!(expected, *c.data());
 }
 


### PR DESCRIPTION
This pull request refactors tensor trait implementations to use references instead of moving ownership. Additionally, it introduces support for binary operations between tensors and `f32`, which simplifies and improves key tensor operations like `mean` and `mean_dim`.